### PR TITLE
Add new conf activation for INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN

### DIFF
--- a/admin/setup_btp.php
+++ b/admin/setup_btp.php
@@ -109,6 +109,11 @@ $linkback = '<a href="' . DOL_URL_ROOT . '/admin/modules.php">'
     }
 
 
+    if(floatval(DOL_VERSION) >= 10){
+        setup_print_on_off('INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN', false, '', 'INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN_HELP');
+    }
+
+
     // INVOICE_USE_SITUATION
     setup_print_title($langs->trans("SetupSituationTitle"));
 

--- a/langs/fr_FR/btp.lang
+++ b/langs/fr_FR/btp.lang
@@ -47,6 +47,8 @@ INVOICE_USE_SITUATION=Activer le support des factures de situation
 INVOICE_USE_SITUATION_CREDIT_NOTE=Activer le support des avoirs de situation
 MAIN_ENABLE_IMPORT_LINKED_OBJECT_LINES=Permettre l'import de lignes issues d'un document lié
 MAIN_ENABLE_IMPORT_LINKED_OBJECT_LINES_HELP=Attention, le nombre de documents compatibles dépend de la version de dolibarr
+INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN=Lors de l'ajout d'une ligne négative dans une facture, ne pas créer de remise fixe
+INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN_HELP=Cette option est une option cachée de Dolibarr, elle n'est pas liée au module BTP
 
 PDFCrabeBtpDescription=Modèle pdf spécifique Situation
 PDFCrabeBtpTitle=Situation n° %d


### PR DESCRIPTION
Ajout d'une conf cachée de dolibarr activable dans l'admin de BTP
Lors de l'ajout d'une ligne négative dans une facture, ne pas créer de remise fixe
Cette option est une option cachée de Dolibarr, elle n'est pas liée au module BTP