### PR TITLE
1.1 fix tk12029 PDF Sponge BTP : ttc price data situation

### DIFF
--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -2987,6 +2987,7 @@ class pdf_sponge_btp extends ModelePDFFactures
 
 		// Retained warranty
 		$retenue_garantie = $this->getRetainedWarrantyAmount($object);
+		if($retenue_garantie == -1) $retenue_garantie = 0;
 
 		$TDataSituation['nouveau_cumul']['retenue_garantie'] = $retenue_garantie + $retenue_garantie_anterieure;
 		$TDataSituation['nouveau_cumul']['total_ttc'] = $TDataSituation['nouveau_cumul']['TTC'] - ($retenue_garantie + $retenue_garantie_anterieure);

--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -3025,7 +3025,10 @@ class pdf_sponge_btp extends ModelePDFFactures
 			 * Si on teste juste "! empty($prevSituationPercent)" toutes les lignes de la 1ere situation sont considérées comme travaux supplémentaires
 			 * Et vu qu'il ne peut pas y avoir de travaux supplémentaires dans la 1ere situation, ça donne ça :
 			 */
-			if(!empty($l->fk_prev_id) || empty($facDerniereSituation->lines)) $TDataSituation['mois']['HT'] += $calc_ht;
+			if(!empty($l->fk_prev_id) || empty($facDerniereSituation->lines)) {
+			    $TDataSituation['mois']['HT'] += $calc_ht;
+                $TDataSituation['mois']['TTC'] = $TDataSituation['mois']['HT']  + $TDataSituation['mois']['TVA'] ;
+            }
 		}
 
 		if(! empty($facDerniereSituation->lines)) {


### PR DESCRIPTION
#FIX PDF Sponge BTP : calcul TTC#
Lorsqu'on calcule le total HT des lignes d'une facture de situation, la valeur TTC n'est pas redéfinie.