### PR TITLE
FIX TK12029 - getDataSituation() : Redéfinir la valeur TTC du mois

### DIFF
--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -3027,6 +3027,8 @@ class pdf_sponge_btp extends ModelePDFFactures
 			 */
 			if(!empty($l->fk_prev_id) || empty($facDerniereSituation->lines)) {
 			    $TDataSituation['mois']['HT'] += $calc_ht;
+			    /* TK12029 Correction mauvais calcul TVA et TTC */
+                $TDataSituation['mois']['TVA'] = $TDataSituation['mois'][$l->tva_tx]['TVA'];
                 $TDataSituation['mois']['TTC'] = $TDataSituation['mois']['HT']  + $TDataSituation['mois']['TVA'] ;
             }
 		}

--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -3025,7 +3025,10 @@ class pdf_sponge_btp extends ModelePDFFactures
 			 * Si on teste juste "! empty($prevSituationPercent)" toutes les lignes de la 1ere situation sont considérées comme travaux supplémentaires
 			 * Et vu qu'il ne peut pas y avoir de travaux supplémentaires dans la 1ere situation, ça donne ça :
 			 */
-			if(!empty($l->fk_prev_id) || empty($facDerniereSituation->lines)) $TDataSituation['mois']['HT'] += $calc_ht;
+			if(!empty($l->fk_prev_id) || empty($facDerniereSituation->lines)) {
+			    $TDataSituation['mois']['HT'] += $calc_ht;
+                $TDataSituation['mois']['TTC'] = $TDataSituation['mois']['HT']  + $TDataSituation['mois']['TVA'] ;
+            }
 		}
 
 		if(! empty($facDerniereSituation->lines)) {


### PR DESCRIPTION
**FIX PDF Sponge BTP : calcul TTC**
Lorsqu'on calcule le total HT des lignes d'une facture de situation, la valeur TTC n'est pas redéfinie.