### PR TITLE
FIX : Error Display TTC pdf_sponge_btp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file
 
 ## 1.1
 
+- FIX : Changement de la valeur de retour par défault dans le cas d'une retenue de garantie à 0% qui provoquait une incohérence entre les deux lignes TTC sur pdf_sponge_btp - 19/11/2021 - *1.1.9*
 - FIX : Traduction sur facture de situation *26/06/2021* - 1.1.8
 - FIX : module descriptor (v14 compatibility) *30/06/2021* - 1.1.7
 - FIX : Remove useless dependency for workstation *29/06/2021* - 1.1.6

--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -3143,6 +3143,10 @@ class pdf_sponge_btp extends ModelePDFFactures
 
 		if(is_callable(array($object, 'getRetainedWarrantyAmount'))){
 			return $object->getRetainedWarrantyAmount($rounding);
+			//On surcharge la valeur de la retenue de garantie car quand elle renvoie -1, elle est interprétée comme une valeur monétaire et réduit le total TTC de 1
+			$retainedDataReturnValue = $object->getRetainedWarrantyAmount($rounding);
+
+			return $retainedDataReturnValue == -1 ? 0 : $retainedDataReturnValue;
 		}
 		else
 		{

--- a/core/modules/modBtp.class.php
+++ b/core/modules/modBtp.class.php
@@ -65,7 +65,7 @@ class modBtp extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module ATM BTP: provides PDF templates specifically designed for the construction industry";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '1.1.8';
+		$this->version = '1.1.9';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION
# FIX

Changement de la valeur de retour par défault dans le cas d'une retenue de garantie à 0% qui provoquait une incohérence entre les deux lignes TTC sur pdf_sponge_btp