### PR TITLE
PULLUP FIX ref commande BTP pdf

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file
 
 ## 1.3
 
+- FIX : dédoublement de la ref commande dans note_public lors de la génération des pdf 'crabe_btp' & 'sponge_btp' *05/10/2022* - 1.3.3
 - FIX : fatal error dans le modèle sponge_btp dû à une fuite de mémoire - *04/08/2022* - 1.3.2
   - suppression de caches inutiles
   - optimisation des calculs en boucle

--- a/core/modules/facture/doc/pdf_crabe_btp.modules.php
+++ b/core/modules/facture/doc/pdf_crabe_btp.modules.php
@@ -2368,7 +2368,8 @@ class pdf_crabe_btp extends ModelePDFFactures
 		$object->fetchObjectLinked();
 		// évite le dédoublement de la ref commande si plusieurs objets liés 'commande'
 		if (($showLinkedObject && count($object->linkedObjects['commande']) > 1) || count($object->linkedObjects['commande']) <= 1){
-			$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);		}
+			$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);		
+			}
 
 		if ($showaddress)
 		{

--- a/core/modules/facture/doc/pdf_crabe_btp.modules.php
+++ b/core/modules/facture/doc/pdf_crabe_btp.modules.php
@@ -365,7 +365,7 @@ class pdf_crabe_btp extends ModelePDFFactures
 
 		/**** FIN TABLEAU SPECIFIQUE ****/
 
-				$this->_pagehead($pdf, $object, 0, $outputlangs);
+				$this->_pagehead($pdf, $object, 0, $outputlangs, FALSE);
 				$pdf->SetFont('','', $default_font_size - 1);
 				$pdf->MultiCell(0, 3, '');		// Set interline to 3
 				$pdf->SetTextColor(0,0,0);
@@ -2212,9 +2212,10 @@ class pdf_crabe_btp extends ModelePDFFactures
 	 *  @param  Object		$object     	Object to show
 	 *  @param  int	    	$showaddress    0=no, 1=yes
 	 *  @param  Translate	$outputlangs	Object lang for output
+	 *  @param  boolean  $showLinkedObject
 	 *  @return	void
 	 */
-	function _pagehead(&$pdf, $object, $showaddress, $outputlangs)
+	function _pagehead(&$pdf, $object, $showaddress, $outputlangs, $showLinkedObject = TRUE)
 	{
 		global $conf,$langs;
 
@@ -2364,7 +2365,10 @@ class pdf_crabe_btp extends ModelePDFFactures
 		$posy+=1;
 
 		// Show list of linked objects
-		$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);
+		$object->fetchObjectLinked();
+		// évite le dédoublement de la ref commande si plusieurs objets liés 'commande'
+		if (($showLinkedObject && count($object->linkedObjects['commande']) > 1) || count($object->linkedObjects['commande']) <= 1){
+			$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);		}
 
 		if ($showaddress)
 		{

--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -414,7 +414,7 @@ class pdf_sponge_btp extends ModelePDFFactures
 
 				/**** FIN TABLEAU SPECIFIQUE ****/
 
-				$this->_pagehead($pdf, $object, 0, $outputlangs);
+				$this->_pagehead($pdf, $object, 0, $outputlangs, FALSE);
 				$pdf->SetFont('','', $default_font_size - 1);
 				$pdf->MultiCell(0, 3, '');		// Set interline to 3
 				$pdf->SetTextColor(0,0,0);
@@ -1836,9 +1836,10 @@ class pdf_sponge_btp extends ModelePDFFactures
 	 *  @param  Object		$object     	Object to show
 	 *  @param  int	    	$showaddress    0=no, 1=yes
 	 *  @param  Translate	$outputlangs	Object lang for output
+	 *  @param  boolean  $showLinkedObject
 	 *  @return	void
 	 */
-	function _pagehead(&$pdf, $object, $showaddress, $outputlangs)
+	function _pagehead(&$pdf, $object, $showaddress, $outputlangs, $showLinkedObject = TRUE)
 	{
 		global $conf, $langs;
 
@@ -2004,7 +2005,13 @@ class pdf_sponge_btp extends ModelePDFFactures
 		$top_shift = 0;
 		// Show list of linked objects
 		$current_y = $pdf->getY();
-		$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);
+
+
+		$object->fetchObjectLinked();
+		// évite le dédoublement de la ref commande si plusieurs objets liés 'commande'
+		if (($showLinkedObject && count($object->linkedObjects['commande']) > 1) || count($object->linkedObjects['commande']) <= 1){
+			$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);
+		}
 		if ($current_y < $pdf->getY())
 		{
 			$top_shift = $pdf->getY() - $current_y;

--- a/core/modules/modBtp.class.php
+++ b/core/modules/modBtp.class.php
@@ -64,7 +64,7 @@ class modBtp extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module ATM BTP: provides PDF templates specifically designed for the construction industry";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '1.3.2';
+		$this->version = '1.3.3';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION


FIX ref commande BTP pdf

Lors de la génération des pdf crabe_btp et sponge_btp
Fix le dédoublement des ref_commande dans note_public si linkedObject > 1
