### PR TITLE
FIX - Encadré des objets liés retiré

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file
 
 ## Release 1.6
 
+- FIX : DA025402 - L'encadré des objets liés dans le pdf sponge btp a été retiré - *30/08/2024* - 1.6.1
 - FIX : Compat v20
   Changed Dolibarr compatibility range to 16 min - 20 max - *04/08/2024* - 1.6.0
 

--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -2005,20 +2005,20 @@ class pdf_sponge_btp extends ModelePDFFactures
 		$posy+=1;
 
 		$top_shift = 0;
-		// Show list of linked objects
-		$current_y = $pdf->getY();
-
-
-		$object->fetchObjectLinked();
-		// évite le dédoublement de la ref commande si plusieurs objets liés 'commande'
-
-		if (isset($object->linkedObjects['commande']) &&   (($showLinkedObject && is_array($object->linkedObjects['commande']) && count($object->linkedObjects['commande']) > 1) || (is_array($object->linkedObjects['commande']) && count($object->linkedObjects['commande'])) <= 1)){
-			$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);
-		}
-		if ($current_y < $pdf->getY())
-		{
-			$top_shift = $pdf->getY() - $current_y;
-		}
+//		// Show list of linked objects
+//		$current_y = $pdf->getY();
+//
+//
+//		$object->fetchObjectLinked();
+//		// évite le dédoublement de la ref commande si plusieurs objets liés 'commande'
+//
+//		if (isset($object->linkedObjects['commande']) &&   (($showLinkedObject && is_array($object->linkedObjects['commande']) && count($object->linkedObjects['commande']) > 1) || (is_array($object->linkedObjects['commande']) && count($object->linkedObjects['commande'])) <= 1)){
+//			$posy = pdf_writeLinkedObjects($pdf, $object, $outputlangs, $posx, $posy, $w, 3, 'R', $default_font_size);
+//		}
+//		if ($current_y < $pdf->getY())
+//		{
+//			$top_shift = $pdf->getY() - $current_y;
+//		}
 
 		if ($showaddress)
 		{

--- a/core/modules/modBtp.class.php
+++ b/core/modules/modBtp.class.php
@@ -67,7 +67,7 @@ class modBtp extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module ATM BTP: provides PDF templates specifically designed for the construction industry";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '1.6.0';
+		$this->version = '1.6.1';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION

L'encadré des objets liés dans le pdf sponge btp a été retiré