### PR TITLE
Fix/support/138/da024860/compat v19 statusinvoiceamendment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file
 
 
 ## Release 1.6
-
+- FIX : dDA024860 supplementary work revamp in pdf situation pdf_sponge_btp - *08/04/2025* - 1.6.4  
 - FIX : Compat v21 - **17/12/2024** - 1.6.3
 - FIX : No depends on modules - *04/09/2024* - 1.6.2
 - FIX : DA025402 - L'encadré des objets liés dans le pdf sponge btp a été retiré - *30/08/2024* - 1.6.1

--- a/core/modules/facture/doc/pdf_sponge_btp.modules.php
+++ b/core/modules/facture/doc/pdf_sponge_btp.modules.php
@@ -3037,7 +3037,7 @@ class pdf_sponge_btp extends ModelePDFFactures
 
 			// Si $prevSituationPercent vaut 0 c'est que la ligne $l est un travail supplémentaire
 			$prevSituationPercent = 0;
-			//@todo à modifier revoir la condition
+
 			if (!empty($l->fk_prev_id)) {
 				$prevSituationPercent = $l->get_prev_progress($object->id, true);
 			}

--- a/core/modules/modBtp.class.php
+++ b/core/modules/modBtp.class.php
@@ -67,7 +67,7 @@ class modBtp extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module ATM BTP: provides PDF templates specifically designed for the construction industry";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '1.6.3';
+		$this->version = '1.6.4';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION

	 * Checks if an invoice line is a supplementary work.
	 *
	 * Main works: lines of the situation invoice that were already present in the previous invoice.
	 * Supplementary works: lines of the invoice that are not part of invoice S1 (as discussed with Johan, new behavior).
	 * Example:
	 * S1 with l1 (main work), l2 (main work)
	 * S2 with l1 (main work), l2 (main work), l3 (supplementary work)
	 * S3 with l1 (main work), l2 (main work), l3 (supplementary work), l4 (supplementary work)
	 